### PR TITLE
Added AfricasTalkingProvider to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Supported providers list:
 
 * [Clickatell](https://github.com/kolypto/py-smsframework-clickatell)
 * [Vianett](https://github.com/kolypto/py-smsframework-vianett)
+* [Africa's Talking](https://pypi.org/project/smsframework-africastalking)
 * Expecting more!
 
 Also see the [full list of providers](https://pypi.python.org/pypi?%3Aaction=search&term=smsframework).

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ Supported providers list:
 
 -  `Clickatell <https://github.com/kolypto/py-smsframework-clickatell>`__
 -  `Vianett <https://github.com/kolypto/py-smsframework-vianett>`__
+-  `Africa's Talking <https://pypi.org/project/smsframework-africastalking>`__
 -  Expecting more!
 
 Also see the `full list of

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     extras_require={
         'clickatell': ['smsframework-clickatell >= 0.0.1'],
         'vianett': ['smsframework-vianett >= 0.0.1'],
-        'receiver': ['flask >= 0.10']
+        'receiver': ['flask >= 0.10'],
+        'africastalking': ['smsframework-africastalking >= 1.0.0']
     },
     tests_require=[
         'nose',


### PR DESCRIPTION
# Changes

- Added reference to Africa'sTalkingProvider in documentation.

# Tests

- No new functionality in repo, no tests affected.

# Links

- https://github.com/BBOXX/py-smsframework-africastalking
- https://pypi.org/project/smsframework-africastalking/